### PR TITLE
Update ptScheduler.cpp

### DIFF
--- a/src/ptScheduler.cpp
+++ b/src/ptScheduler.cpp
@@ -657,6 +657,8 @@ bool ptScheduler::setIteration (int32_t value) {
       return false;
       break;
   }
+  
+  return false;
 }
 
 //=======================================================================//


### PR DESCRIPTION
Returning false at the end of setInterval function to avoid error "control reaches end of non-void function [-Werror=return-type]" on compilation.